### PR TITLE
Correction of the "view items" link during funder lookup

### DIFF
--- a/dspace/config/spring/api/discovery.xml
+++ b/dspace/config/spring/api/discovery.xml
@@ -109,6 +109,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterSubject" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterFunder" />
             </list>
         </property>
         <!--The sort filters for the discovery search-->
@@ -214,6 +215,7 @@
                 <ref bean="searchFilterAuthor" />
                 <ref bean="searchFilterSubject" />
                 <ref bean="searchFilterIssued" />
+                <ref bean="searchFilterFunder" />
             </list>
         </property>
         <!--The sort filters for the discovery search (same as defaultConfiguration above)-->
@@ -402,6 +404,16 @@
             </list>
         </property>
         <property name="type" value="date"/>
+        <property name="sortOrder" value="VALUE"/>
+    </bean>
+    <bean id="searchFilterFunder" class="org.dspace.discovery.configuration.DiscoverySearchFilterFacet">
+        <property name="indexFieldName" value="funder"/>
+        <property name="metadataFields">
+            <list>
+                <value>rioxxterms.funder</value>
+            </list>
+        </property>
+        <property name="facetLimit" value="10"/>
         <property name="sortOrder" value="VALUE"/>
     </bean>
 

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2533,5 +2533,6 @@
 		<h3>{0}</h3>
 		<p>If you are uploading multiple files as part of this submission, please ensure this file is marked as "Primary".</p>
 	</message>
+    <message key="xmlui.ArtifactBrowser.SimpleSearch.filter.funder">Funder</message>
 
 </catalogue>

--- a/dspace/modules/xmlui/src/main/webapp/static/js/person-lookup.js
+++ b/dspace/modules/xmlui/src/main/webapp/static/js/person-lookup.js
@@ -164,7 +164,11 @@ function AuthorLookup(url, authorityInput, collectionID) {
                 }
 
                 if (aData['insolr'] != "false") {
-                    var discoverLink = window.orcid.contextPath + "/discover?filtertype=author&filter_relational_operator=authority&filter=" + aData['insolr'];
+                    var filterType = "author";
+                    if(funderField){
+                        filterType = "funder";
+                    }
+                    var discoverLink = window.orcid.contextPath + "/discover?filtertype=" + filterType + "&filter_relational_operator=authority&filter=" + aData['insolr'];
                     vcard.find('.vcard-insolr span').empty().append('<a href="' + discoverLink + '" target="_new">view items</a>');
                 } else {
                     vcard.find('.vcard-insolr span').text("0");


### PR DESCRIPTION
The actual link behind "view items" now links to the authority for funders instead of authors, which wouldn't return any results.
