### PR TITLE
W2p 36799 open acces location uri support

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Existing fields from the dc and dcterms namespace were used where possible. A nu
 | dc.description.abstract| dc:description| example item | ` <dc:description> `<br> `example item`<br>`</dc:description>`|
 | Bitstream metadata| dc:format| See separate table with bitstream derived metadata below. | See separate table with bitstream derived metadata below. |
 | Bitstream metadata| dc:identifier| See separate table with bitstream derived metadata below. | See separate table with bitstream derived metadata below. |
+| rioxxterms.openaccess.uri| dc:identifier| See separate table with bitstream derived metadata below. | See separate table with bitstream derived metadata below. |
 | dc.language.iso| dc:language | en-GB|`<dc:language> ` <br> ` en-GB ` <br> `  </dc:language>` |
 | dc.publisher| dc:publisher | PLOS ONE|` <dc:publisher> `<br> `PLOS ONE`<br>`</dc:publisher>`|
 | dc.relation.uri| dc:relation |[http://datadryad.org/resource/doi:10.5061/dryad.tg469](http://datadryad.org/resource/doi:10.5061/dryad.tg469) |`<dc:relation>`<br>`http://datadryad.org/resource/doi:10.5061/dryad.tg469`<br>`</dc:relation>`|
@@ -411,7 +412,7 @@ error: dspace/pom.xml: patch does not apply
 The RIOXX OAI-PMH endpoint has been developed in such a way that it only exposes items that are RIOXX compliant. An item will not appear there as long as not all of the following mandatory fields are present in the item:
 
 * ali:license_ref
-* dc:identifier that directly links to the attached bitstream
+* dc:identifier that directly links to the attached bitstream (This can be both the bitstream as provided to DSpace or a URI to the full text publication hosted elsewhere)
 * dc:language
 * dc:title
 * dcterms:dateAccepted
@@ -421,4 +422,4 @@ The RIOXX OAI-PMH endpoint has been developed in such a way that it only exposes
 * rioxxterms:version
 
 According to the specification, dc.source is mandatory where applicable (ISSN or ISBN). Currently, DSpace is not enforcing this in the OAI-PMH endpoint and will just expose ISSN or ISBN when they are present in the metadata.   
-Again, aside from these metadatafields, make sure that the item contains a bitstream (file). Metadata records without bitstreams will not be exposed through the RIOXX OAI-PMH endpoint.
+Again, aside from these metadatafields, make sure that the item contains a bitstream (file), or a value in the rioxxterms.openaccess.uri that links to the full text publication hosted elsewhere. Metadata records without bitstreams/openacces URI will not be exposed through the RIOXX OAI-PMH endpoint.

--- a/dspace/config/crosswalks/oai/metadataFormats/rioxx.xsl
+++ b/dspace/config/crosswalks/oai/metadataFormats/rioxx.xsl
@@ -92,6 +92,12 @@
                 </dc:identifier>
             </xsl:for-each>
 
+            <xsl:for-each select="doc:metadata/doc:element[@name='rioxxterms']/doc:element[@name='openaccess']/doc:element[@name='uri']/doc:element/doc:field[@name='value']">
+                <dc:identifier>
+                    <xls:value-of select="."/>
+                </dc:identifier>
+            </xsl:for-each>
+
             <xsl:for-each select="doc:metadata/doc:element[@name='dc']/doc:element[@name='language']/doc:element[@name='iso']/doc:element/doc:field[@name='value']">
                 <dc:language>
                     <xls:value-of select="."/>

--- a/dspace/config/crosswalks/oai/xoai.xml
+++ b/dspace/config/crosswalks/oai/xoai.xml
@@ -350,7 +350,14 @@
                                     <RightCondition>
                                         <And>
                                             <LeftCondition>
-                                                <Custom ref="itemsWithBitstreamsFilter"/>
+                                                <Or>
+                                                    <LeftCondition>
+                                                        <Custom ref="itemsWithBitstreamsFilter"/>
+                                                    </LeftCondition>
+                                                    <RightCondition>
+                                                        <Custom ref="openAccessUriAvailable"/>
+                                                    </RightCondition>
+                                                </Or>
                                             </LeftCondition>
                                             <RightCondition>
                                                 <Custom ref="rioxxLangExistsCondition"/>
@@ -572,6 +579,13 @@
 
         <CustomCondition id="itemsWithBitstreamsFilter">
             <Class>org.dspace.xoai.filter.ItemsWithBitstreamFilter</Class>
+        </CustomCondition>
+
+        <CustomCondition id="openAccessUriAvailable">
+            <Class>org.dspace.xoai.filter.DSpaceMetadataExistsFilter</Class>
+            <Configuration>
+                <string name="field">rioxxterms.openaccess.uri</string>
+            </Configuration>
         </CustomCondition>
 
     </Filters>

--- a/dspace/config/input-forms.xml
+++ b/dspace/config/input-forms.xml
@@ -210,6 +210,17 @@ it, please enter the types and the actual numbers or codes.</hint>
 
        <field>
          <dc-schema>rioxxterms</dc-schema>
+         <dc-element>openaccess</dc-element>
+         <dc-qualifier>uri</dc-qualifier>
+         <repeatable>false</repeatable>
+         <label>Open access location URI</label>
+         <input-type>onebox</input-type>
+         <hint>xmlui.submission.submit.input.rioxxterms.openaccess.uri</hint>
+         <required></required>
+       </field>
+
+       <field>
+         <dc-schema>rioxxterms</dc-schema>
          <dc-element>versionofrecord </dc-element>
          <dc-qualifier></dc-qualifier>
          <repeatable>false</repeatable>

--- a/dspace/config/registries/rioxxterms-types.xml
+++ b/dspace/config/registries/rioxxterms-types.xml
@@ -66,6 +66,12 @@
         <scope_note></scope_note>
     </dc-type>
 
+    <dc-type>
+        <schema>rioxxterms</schema>
+        <element>openaccess</element>
+        <qualifier>uri</qualifier>
+        <scope_note>URL to the full text publication</scope_note>
+    </dc-type>
 
 
 </dspace-dc-types>

--- a/dspace/modules/oai/src/main/java/org/dspace/xoai/filter/OrFilter.java
+++ b/dspace/modules/oai/src/main/java/org/dspace/xoai/filter/OrFilter.java
@@ -1,0 +1,46 @@
+/**
+ * The contents of this file are subject to the license and copyright
+ * detailed in the LICENSE and NOTICE files at the root of the source
+ * tree and available online at
+ *
+ * http://www.dspace.org/license/
+ */
+package org.dspace.xoai.filter;
+
+import org.dspace.core.Context;
+import org.dspace.xoai.data.DSpaceItem;
+import org.dspace.xoai.filter.results.DatabaseFilterResult;
+import org.dspace.xoai.filter.results.SolrFilterResult;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class OrFilter extends DSpaceFilter {
+    private DSpaceFilter left;
+    private DSpaceFilter right;
+
+    public OrFilter(DSpaceFilter left, DSpaceFilter right) {
+        this.left = left;
+        this.right = right;
+    }
+
+    @Override
+    public DatabaseFilterResult buildDatabaseQuery(Context context) {
+        DatabaseFilterResult leftResult = left.buildDatabaseQuery(context);
+        DatabaseFilterResult rightResult = right.buildDatabaseQuery(context);
+        List<Object> param = new ArrayList<Object>();
+        param.addAll(leftResult.getParameters());
+        param.addAll(rightResult.getParameters());
+        return new DatabaseFilterResult("("+leftResult.getQuery()+") OR ("+ rightResult.getQuery() +")", param);
+    }
+
+    @Override
+    public SolrFilterResult buildSolrQuery() {
+        return new SolrFilterResult("("+left.buildSolrQuery()+") OR ("+right.buildSolrQuery()+")");
+    }
+
+    @Override
+    public boolean isShown(DSpaceItem item) {
+        return left.isShown(item) || right.isShown(item);
+    }
+}

--- a/dspace/modules/oai/src/main/java/org/dspace/xoai/filter/OrFilter.java
+++ b/dspace/modules/oai/src/main/java/org/dspace/xoai/filter/OrFilter.java
@@ -36,7 +36,7 @@ public class OrFilter extends DSpaceFilter {
 
     @Override
     public SolrFilterResult buildSolrQuery() {
-        return new SolrFilterResult("("+left.buildSolrQuery()+") OR ("+right.buildSolrQuery()+")");
+        return new SolrFilterResult("("+left.buildSolrQuery().getQuery()+") OR ("+right.buildSolrQuery().getQuery()+")");
     }
 
     @Override

--- a/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
+++ b/dspace/modules/xmlui/src/main/webapp/i18n/messages.xml
@@ -2534,4 +2534,10 @@
 		<p>If you are uploading multiple files as part of this submission, please ensure this file is marked as "Primary".</p>
 	</message>
 
+    <message key="xmlui.submission.submit.input.rioxxterms.openaccess.uri">
+        <p>If you are not able to upload the full text of your submission but the full text is available elsewhere, you
+            can the URL to the full text on that location here.
+        </p>
+    </message>
+
 </catalogue>


### PR DESCRIPTION
- Fix for the OrFilter class required for the differentiation between the bitstream URL and openaccess.uri
- Addition and configuration of rioxxterms.openaccess.uri field
